### PR TITLE
Add Supercast Pattern

### DIFF
--- a/patterns.txt
+++ b/patterns.txt
@@ -8,3 +8,4 @@ Patreon Subscribers:   /patreon\.com.*auth=/i
 Slate Plus:            /my\.slate\.com\/subscriptions\//i
 Memberful:             /memberfulcontent\.com.*auth\=/i
 Substack:              /substack\.com.*\/private\/.*\.rss/i
+Supercast:             /supercast\.(tech|com)\/feeds\//i


### PR DESCRIPTION
All feeds from Supercast are individualized and should not be indexed. They can be hosted on `supercast.tech` or `supercast.com` and can contain a subdomain (but may not).

Examples I tested this against (feed tokens are illustrative and not legit):

```
https://supercast.tech/feeds/j302h20ihio23j
https://blah.supercast.tech/feeds/39h2jijlkfsdhjklsdhfklds
https://supercast.com/feeds/39h2jijlkfsdhjklsdhfklds
https://blah.supercast.com/feeds/39h2jijlkfsdhjklsdhfklds
```