### PR TITLE
Supporting Cast content regex added to patterns.txt

### DIFF
--- a/patterns.txt
+++ b/patterns.txt
@@ -10,3 +10,4 @@ Memberful:             /memberfulcontent\.com.*auth\=/i
 Substack:              /substack\.com.*\/private\/.*\.rss/i
 Supercast:             /supercast\.(tech|com)\/feeds\//i
 Captivate:             /private\.captivate\.fm/i
+Supporting Cast:       /supportingcast\.(fm|co|cc)\/content\//i


### PR DESCRIPTION
Per [this tweet](https://twitter.com/PodcastindexOrg/status/1428006858028158977) from Podcastindex-org, we have abided by the request therein.  