### PR TITLE
Fixes unescaped forward slashes on 3 entries

### DIFF
--- a/patterns.txt
+++ b/patterns.txt
@@ -1,5 +1,5 @@
 Stratechery Private:   /rss\.stratechery\.com/i
-Bing synthetic feeds:  /bing\.com/search/i
+Bing synthetic feeds:  /bing\.com\/search/i
 Listenlater:           /listenlater\.fm/i
 Spotify Scraper:       /spotifeed\.timdorr/i
 Urls with Basic Auth:  /(.+?\/\/)(.+?):(.+?)@(.+)/i
@@ -17,8 +17,8 @@ RedCircle:             /(api.podcache.net\/shows|feeds\.redcircle\.com)\/[a-z0-9
 HuffDuffer:            /\.huffduffer.com/i
 Podcast.co:            /feed\.pod\.co\/[a-zA-Z0-9-]{36}\/[a-zA-Z0-9-]{36}/i
 ATP:                   /atp\.fm\/rss\/[a-zA-Z0-9]*/i
-Mysterious Universe:   /mysteriousuniverse\.org/feed/mu.*/i
-Sam Harris:            /samharris.org/feed/\?token\=[a-zA-Z0-9-]{36}/i
+Mysterious Universe:   /mysteriousuniverse\.org\/feed\/mu.*/i
+Sam Harris:            /samharris.org\/feed\/\?token\=[a-zA-Z0-9-]{36}/i
 Acast Access:          /access\.acast\.com\/[^\/]+\/(?!default).+/i
 Anchor:                /anchor\.fm\/s\/\.*\/podcast\/auth\//i
 Anchor:                /anchor\.fm\/s\/.*\/podcast\/private.*token\=/i


### PR DESCRIPTION
The regular expressions for Bing synthetic feeds, Mysterious Universe and Sam Harris all included unescaped forward slashes making them invalid - this PR fixes them up.